### PR TITLE
tox: add ability to pass extra args to pytest

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ deps =
     pytest-cov
 commands =
     pip install -U pip
-    pytest --cov --cov-append --cov-report=term-missing  --cov-fail-under=95 tests
+    pytest --cov --cov-append --cov-report=term-missing  --cov-fail-under=95 {posargs:tests}
 depends =
     {py311}: clean
     report: py311


### PR DESCRIPTION
e.g:

    tox -e py3 -- -vvv tests/test_anonymizor.py
